### PR TITLE
Adr/cypress tests

### DIFF
--- a/docs/adr/0002-2021-02-19-frontend-form-validation.md
+++ b/docs/adr/0002-2021-02-19-frontend-form-validation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Deprecated - we've refactored form validation in [this PR](https://github.com/mcagov/beacons-webapp/pull/123).
 
 ## Context
 

--- a/docs/adr/0004-2021-03-03-frontend-e2e-tests.md
+++ b/docs/adr/0004-2021-03-03-frontend-e2e-tests.md
@@ -1,0 +1,65 @@
+# Fontend end-to-end testing
+
+## Status
+
+Accepted
+
+## Context
+
+The [frontend application](https://github.com/mcagov/beacons-webapp) currently does not have end-to-end tests, and we feel that adding them would help development of the app.
+
+## Decision
+
+We will use [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell) to write end-to-end tests for the frontend app in the [frontend repository](https://github.com/mcagov/beacons-webapp).
+
+These tests will be used to check the functionality of the application and its pages.
+
+These tests are `end-to-end` within the frontend app - we would mock any API calls from the frontend.
+
+We will also continue to use unit tests to test other (lower level?) logic that Cypress tests will not cover.
+
+For example:
+
+- Testing that the `back` button on a page will take you to the previous page - Cypress test
+- Testing that the `handlePageRequest` function works as expected - unit test
+
+## Key Benefits
+
+- Allows us to add tests that align with Acceptance Criteria
+- Gives us confidence that our changes will not break functionality in the app
+- Reduces the need for manual testing
+
+## Key Drawbacks
+
+- Requires time and effort in the development process as devs will need to take time to write these tests
+- Slows down the test suite and therefore the CI/CD pipeline and deployment process
+
+## Alternatives
+
+We could continue not having end-to-end tests:
+
+- We would always need manual testing as we make changes
+- This is time-consuming and possibly not as thorough as automated tests based on Acceptance Criteria
+
+We could use a different testing tool, such as [Selenium](https://www.selenium.dev/documentation/en/):
+
+- Selenium has been around longer than Cypress
+- Members of the team have had negative experiences using it
+- Cypress is a well-know alternative and is gaining popularity
+
+## Consequences
+
+The development team might be slowed down initially, as we would need to take time and effort to add tests around existing pages.
+
+However, a lot of that work will be reusable code (e.g. a reusable function for checking the back button).
+
+So once that is in place, adding tests for new pages shouldn't be as time-consuming and should help us develop faster.
+
+## Supporting Documentation
+
+- [Trello ticket for implementing Cypress](https://trello.com/c/U7YwzUsE/282-set-up-end-to-end-functional-tests-integration)
+- [PR for this work](https://github.com/mcagov/beacons-webapp/pull/128)
+- [Cypress docs](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell)
+- [Selenium docs](https://www.selenium.dev/documentation/en/)
+- [Cypress vs. Selenium](https://blog.logrocket.com/cypress-io-the-selenium-killer/)
+- [Cypress vs Selenium: Key Differences](https://www.browserstack.com/guide/cypress-vs-selenium)

--- a/docs/adr/0004-2021-03-03-frontend-integration-tests.md
+++ b/docs/adr/0004-2021-03-03-frontend-integration-tests.md
@@ -1,4 +1,4 @@
-# Fontend end-to-end testing
+# Frontend integration testing
 
 ## Status
 
@@ -6,15 +6,15 @@ Accepted
 
 ## Context
 
-The [frontend application](https://github.com/mcagov/beacons-webapp) currently does not have end-to-end tests, and we feel that adding them would help development of the app.
+The [frontend application](https://github.com/mcagov/beacons-webapp) currently does not have integration tests, and we feel that adding them would help development of the app.
 
 ## Decision
 
-We will use [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell) to write end-to-end tests for the frontend app in the [frontend repository](https://github.com/mcagov/beacons-webapp).
+We will use [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html#In-a-nutshell) to write integration tests for the frontend app in the [frontend repository](https://github.com/mcagov/beacons-webapp).
 
 These tests will be used to check the functionality of the application and its pages.
 
-These tests are `end-to-end` within the frontend app - we would mock any API calls from the frontend.
+These `integration` tests are within the frontend app - we would mock any API calls from the frontend.
 
 We will also continue to use unit tests to test other (lower level?) logic that Cypress tests will not cover.
 
@@ -22,6 +22,12 @@ For example:
 
 - Testing that the `back` button on a page will take you to the previous page - Cypress test
 - Testing that the `handlePageRequest` function works as expected - unit test
+
+Following a discussion around the different types of tests and their definitions, we see them as:
+
+- Unit tests - isolated units tested in both the webapp and API repositories
+- Integration tests - tests between system boundaries. API = API service and Database, Webapp = user/browser and webapp
+- End-to-End tests - Testing end-to-end flow = webapp, service, database
 
 ## Key Benefits
 
@@ -36,7 +42,7 @@ For example:
 
 ## Alternatives
 
-We could continue not having end-to-end tests:
+We could continue not having integration tests:
 
 - We would always need manual testing as we make changes
 - This is time-consuming and possibly not as thorough as automated tests based on Acceptance Criteria

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -8,6 +8,7 @@ This log lists the Architectural Decision Records (ADRs) for the Beacons Registr
 - [ADR-0001-2021-01-28](0001-2021-01-28-technology-choices.md) - Technology Choices
 - [ADR-0002-2021-02-19](0002-2021-02-19-frontend-form-validation.md) - Frontend form validation
 - [ADR-0003-2021-02-24](0003-2021-02-24-when-to-adr.md) - When to create an ADR
+- [ADR-0004-2021-03-03](0004-2021-03-03-frontend-e2e-tests.md) - Fontend end-to-end testing
 
 <!-- adrlogstop -->
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -8,7 +8,7 @@ This log lists the Architectural Decision Records (ADRs) for the Beacons Registr
 - [ADR-0001-2021-01-28](0001-2021-01-28-technology-choices.md) - Technology Choices
 - [ADR-0002-2021-02-19](0002-2021-02-19-frontend-form-validation.md) - Frontend form validation
 - [ADR-0003-2021-02-24](0003-2021-02-24-when-to-adr.md) - When to create an ADR
-- [ADR-0004-2021-03-03](0004-2021-03-03-frontend-e2e-tests.md) - Fontend end-to-end testing
+- [ADR-0004-2021-03-03](0004-2021-03-03-frontend-integration-tests.md) - Frontend integration testing
 
 <!-- adrlogstop -->
 


### PR DESCRIPTION
Add ADR for using Cypress for ~~end-to-end~~ integration tests in the frontend application.
- I dont' feel 100% confident about what I've written here, so please suggest changes!
- Unsure if I accurately covered why we don't want to use Selenium

Mark form validation ADR as deprecated, because I think it's now not accurate after the reafctor.
- Please correct me if I'm wrong!
- Or if I should do this differently