### PR TITLE
Change webapp healthcheck protocol to TCP from http

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -41,10 +41,9 @@ resource "aws_alb_target_group" "webapp" {
   health_check {
     healthy_threshold   = "3"
     interval            = "30"
-    protocol            = "HTTP"
-    matcher             = "200"
+    protocol            = "TCP"
     timeout             = "3"
-    path                = var.webapp_health_check_path
+    port                = "3000"
     unhealthy_threshold = "2"
   }
 


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->
Would this allow the load balancer to check that the webapp is up, without being stopped by basic auth?
## Changes in this pull request

<!-- List all the changes, if there are UI changes, please include Before and After screenshots.  -->
Change webapp healthcheck protocol to TCP from http
## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->
https://stackoverflow.com/a/23921643
