### PR TITLE
Update ingress inbound security group onto the ecs tasks security group

### DIFF
--- a/terraform/security.tf
+++ b/terraform/security.tf
@@ -50,23 +50,20 @@ resource "aws_security_group" "ecs_tasks" {
     security_groups = [aws_security_group.lb.id]
   }
 
+  ingress {
+    description     = "Allow inbound traffic from the webapp to the API"
+    protocol        = "tcp"
+    from_port       = var.service_port
+    to_port         = var.service_port
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
   egress {
     protocol    = "-1"
     from_port   = 0
     to_port     = 0
     cidr_blocks = ["0.0.0.0/0"]
   }
-}
-
-# Allow inbound traffic to the API from the webapp in the same subnet
-resource "aws_security_group_rule" "webapp_to_api" {
-  type                     = "ingress"
-  protocol                 = "tcp"
-  from_port                = var.service_port
-  to_port                  = var.service_port
-  security_group_id        = aws_security_group.ecs_tasks.id
-  source_security_group_id = aws_security_group.ecs_tasks.id
-  depends_on               = [aws_security_group.ecs_tasks]
 }
 
 resource "aws_security_group" "db" {


### PR DESCRIPTION
## Context

- There needs to be an ingress route from the webapp to the API to allow the webapp to post the registration
- This required us to create a security group rule that allows inbound access from the security group that the webapp and API are deployed in, as they are in the same subnets and have the same security group applied onto them

## Changes in this pull request

- There is an issue with creating inline security group rules as they will be overwritten by Terraform, [see docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule)
- This is only seen when the security group is modified which happens when the ECS task definition is updated, which is why we only noticed the security group rule being removed until an update was made to the ECS tasks

## Guidance to review

- Update the security group rule inline

## Things to check

- [ ] Environment variables have been updated
