### PR TITLE
Frontend ssl persistent

### DIFF
--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -5,7 +5,35 @@ resource "aws_alb" "main" {
   security_groups = [aws_security_group.lb.id]
 }
 
-# TODO: Update this listener to redirect all traffic to 443
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_alb.main.id
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "front_end" {
+  load_balancer_arn = aws_alb.main.arn
+  port = "443"
+  protocol = "HTTPS"
+  ssl_policy = "ELBSecurityPolicy-2016-08"
+  certificate_arn = "arn:aws:acm:eu-west-2:232705206979:certificate/b75eecc6-fff7-4114-b100-b1f0eb0641d7"
+
+  default_action {
+    target_group_arn = aws_alb_target_group.webapp.id
+    type             = "forward"
+  }
+}
+
 resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.main.id
   port              = 80

--- a/terraform/alb.tf
+++ b/terraform/alb.tf
@@ -5,7 +5,7 @@ resource "aws_alb" "main" {
   security_groups = [aws_security_group.lb.id]
 }
 
-resource "aws_lb_listener" "front_end" {
+resource "aws_alb_listener" "front_end" {
   load_balancer_arn = aws_alb.main.id
   port              = "80"
   protocol          = "HTTP"
@@ -21,23 +21,12 @@ resource "aws_lb_listener" "front_end" {
   }
 }
 
-resource "aws_lb_listener" "front_end" {
-  load_balancer_arn = aws_alb.main.arn
-  port = "443"
-  protocol = "HTTPS"
-  ssl_policy = "ELBSecurityPolicy-2016-08"
-  certificate_arn = "arn:aws:acm:eu-west-2:232705206979:certificate/b75eecc6-fff7-4114-b100-b1f0eb0641d7"
-
-  default_action {
-    target_group_arn = aws_alb_target_group.webapp.id
-    type             = "forward"
-  }
-}
-
 resource "aws_alb_listener" "front_end" {
-  load_balancer_arn = aws_alb.main.id
-  port              = 80
-  protocol          = "HTTP"
+  load_balancer_arn = aws_alb.main.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "arn:aws:acm:eu-west-2:232705206979:certificate/b75eecc6-fff7-4114-b100-b1f0eb0641d7"
 
   default_action {
     target_group_arn = aws_alb_target_group.webapp.id


### PR DESCRIPTION
Persist SSL settings to API

Definitely worth considering having the SSL ARN in an env var, but it's in no way secret and it seems common to have SSL ARNs there.