### PR TITLE
Added API service health check to r53 us-east and dashboard widget

### DIFF
--- a/terraform/dashboard.tf
+++ b/terraform/dashboard.tf
@@ -195,6 +195,24 @@ resource "aws_cloudwatch_dashboard" "service_health" {
             "x": 6,
             "type": "metric",
             "properties": {
+                "title": "API Health",
+                "annotations": {
+                    "alarms": [
+                        "${aws_cloudwatch_metric_alarm.service_health.arn}"
+                    ]
+                },
+                "view": "singleValue",
+                "stacked": false,
+                "type": "chart"
+            }
+        },
+        {
+            "height": 3,
+            "width": 6,
+            "y": 2,
+            "x": 12,
+            "type": "metric",
+            "properties": {
                 "title": "Webapp Task Count",
                 "annotations": {
                     "alarms": [
@@ -206,7 +224,7 @@ resource "aws_cloudwatch_dashboard" "service_health" {
         },
         {
             "type": "metric",
-            "x": 12,
+            "x": 18,
             "y": 2,
             "width": 6,
             "height": 3,

--- a/terraform/health.tf
+++ b/terraform/health.tf
@@ -27,3 +27,33 @@ resource "aws_route53_health_check" "webapp_health_check" {
   type              = "HTTPS_STR_MATCH"
   search_string     = "Ship shape and Bristol fashion"
 }
+
+resource "aws_cloudwatch_metric_alarm" "service_health" {
+  namespace           = "AWS/Route53"
+  alarm_name          = "service-health-alarm"
+  metric_name         = "HealthCheckStatus"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "0"
+  alarm_description   = "This metric monitors API service health"
+  provider            = aws.us-east
+  alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_service_alerts.arn] : []
+  ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_service_alerts.arn] : []
+
+  dimensions = {
+    HealthCheckId = aws_route53_health_check.service_health_check.id
+  }
+}
+
+resource "aws_route53_health_check" "service_health_check" {
+  reference_name    = "service-health-check"
+  failure_threshold = 5
+  fqdn              = var.webapp_fqdn
+  port              = 443
+  request_interval  = "30"
+  resource_path     = var.service_health_check_path
+  type              = "HTTPS_STR_MATCH"
+  search_string     = "UP"
+}


### PR DESCRIPTION
## Context

Added a public endpoint health check for the API service with alert and dashboard widget

## Changes in this pull request

API Health check in route53
Alarm for the health check
Dashboard widget for the health check

## Guidance to review

Hard to test without deploy so here is a screenshot

![Screenshot 2021-09-02 at 16 50 27](https://user-images.githubusercontent.com/20651/131876943-006facec-ed0b-4d57-a6a7-c6cedbe91882.png)
![Screenshot 2021-09-02 at 16 50 15](https://user-images.githubusercontent.com/20651/131876958-5067bac0-4c73-4dad-9a10-37c78c6f63dc.png)
