### PR TITLE
added enable_alerts to staging workflow as a configurable option to e…

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -66,4 +66,5 @@ jobs:
           TF_VAR_service_basic_auth_password: ${{ secrets.SERVICE_BASIC_AUTH_PASSWORD }}
           TF_VAR_alert_email_address: ${{ secrets.ALERT_EMAIL_ADDRESS }}
           TF_VAR_aws_account_number: ${{ secrets.AWS_ACCOUNT_NUMBER }}
+          TF_VAR_enable_alerts: ${{ secrets.ENABLE_ALERTS }}
         run: terraform apply -auto-approve -var-file=staging.tfvars -var-file=staging.images.tfvars

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,6 +7,10 @@ on:
         description: "Deploy dev onto staging? (true/false)"
         required: false
         default: "true"
+      enableAlerts:
+        description: "Enable alerts? (true/false)"
+        required: false
+        default: "false"
 
 env:
   TERRAFORM_VERSION: 1.0.0
@@ -66,5 +70,5 @@ jobs:
           TF_VAR_service_basic_auth_password: ${{ secrets.SERVICE_BASIC_AUTH_PASSWORD }}
           TF_VAR_alert_email_address: ${{ secrets.ALERT_EMAIL_ADDRESS }}
           TF_VAR_aws_account_number: ${{ secrets.AWS_ACCOUNT_NUMBER }}
-          TF_VAR_enable_alerts: ${{ secrets.ENABLE_ALERTS }}
+          TF_VAR_enable_alerts: ${{ github.event.inputs.enableAlerts }}
         run: terraform apply -auto-approve -var-file=staging.tfvars -var-file=staging.images.tfvars

--- a/terraform/staging.images.tfvars
+++ b/terraform/staging.images.tfvars
@@ -1,2 +1,2 @@
-webapp_image_tag  = "5841f2c44ecb15709ba9b53606e233678316b45d"
+webapp_image_tag  = "52c5f927c7700ba7e1af0a3359ac34ca12d0c183"
 service_image_tag = "3962115345ad69fcbbae96710a0fcc340381f818"

--- a/terraform/staging.tfvars
+++ b/terraform/staging.tfvars
@@ -30,7 +30,6 @@ backup_retention_period                 = 5
 performance_insights_enabled            = true
 apply_immediately                       = true
 rds_multi_az                            = false
-enable_alerts                           = false
 api_service_minimum_task_count          = 1
 webapp_minimum_task_count               = 1
 webapp_fqdn                             = "staging.406beacons.com"


### PR DESCRIPTION
Enable toggling alerts for the staging environment only

## Context

To enable end to end testing of alerting in a production like environment. By default enable_alerts is always off for dev, on for production but it makes sense to make it configurable for staging.

## Changes in this pull request

Change to the staging workflow to pull the enable_alerts variable from the workflow input and remove the hardcoded variable which previously always forced it to be off for staging.
