### PR TITLE
Health alarm fix

### DIFF
--- a/terraform/health.tf
+++ b/terraform/health.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "webapp_health" {
   namespace           = "AWS/Route53"
-  alarm_name          = "webapp-health-alarm"
+  alarm_name          = "${aws_ecs_service.service.name}-webapp-health-alarm"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -30,7 +30,7 @@ resource "aws_route53_health_check" "webapp_health_check" {
 
 resource "aws_cloudwatch_metric_alarm" "service_health" {
   namespace           = "AWS/Route53"
-  alarm_name          = "service-health-alarm"
+  alarm_name          = "${aws_ecs_service.service.name}-service-health-alarm"
   metric_name         = "HealthCheckStatus"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/terraform/staging.images.tfvars
+++ b/terraform/staging.images.tfvars
@@ -1,2 +1,2 @@
-webapp_image_tag  = "52c5f927c7700ba7e1af0a3359ac34ca12d0c183"
-service_image_tag = "b396a4333e21f6d5e5f7fa2a639136b7fc20c358"
+webapp_image_tag  = "42a3a0e4a67dae4cf4bec21fb6f515879d6fb46d"
+service_image_tag = "174815cca0e5b48049a2a141486edd7b6fe4f89b"


### PR DESCRIPTION
## Context

Fixes a bug where health alarms were not named per environment causing them to overwrite each other during deployment.

This mean that you only ever saw health alarms/alerts for the most recently deployed environment.
