### PR TITLE
changed default behaviour for cw alarms for missing data to treat as…

### DIFF
--- a/terraform/cloudwatch.tf
+++ b/terraform/cloudwatch.tf
@@ -17,6 +17,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_service_task_count_too_low" {
   period              = 60
   statistic           = "SampleCount"
   threshold           = var.api_service_minimum_task_count
+  treat_missing_data  = "breaching"
   alarm_description   = "Task count is too low."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
@@ -37,6 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_service_cpu_too_high" {
   period              = 300
   statistic           = "Average"
   threshold           = 80
+  treat_missing_data  = "breaching"
   alarm_description   = "Average CPU utilization is too high."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
@@ -57,6 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_service_memory_too_high" {
   period              = 300
   statistic           = "Average"
   threshold           = 80
+  treat_missing_data  = "breaching"
   alarm_description   = "Average Memory utilization is too high."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
@@ -77,6 +80,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_webapp_task_count_too_low" {
   period              = 60
   statistic           = "SampleCount"
   threshold           = var.webapp_minimum_task_count
+  treat_missing_data  = "breaching"
   alarm_description   = "Task count is too low."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
@@ -97,6 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_webapp_cpu_too_high" {
   period              = 300
   statistic           = "Average"
   threshold           = 80
+  treat_missing_data  = "breaching"
   alarm_description   = "Average CPU utilization is too high."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
@@ -117,6 +122,7 @@ resource "aws_cloudwatch_metric_alarm" "ecs_webapp_memory_too_high" {
   period              = 300
   statistic           = "Average"
   threshold           = 80
+  treat_missing_data  = "breaching"
   alarm_description   = "Average Memory utilization is too high."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
@@ -137,6 +143,7 @@ resource "aws_cloudwatch_metric_alarm" "redis_memory_too_high" {
   period              = 300
   statistic           = "Average"
   threshold           = 80
+  treat_missing_data  = "breaching"
   alarm_description   = "Average Memory utilization is too high."
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []
   ok_actions          = var.enable_alerts == true ? [aws_sns_topic.sns_technical_alerts.arn] : []

--- a/terraform/health.tf
+++ b/terraform/health.tf
@@ -7,6 +7,7 @@ resource "aws_cloudwatch_metric_alarm" "webapp_health" {
   period              = "60"
   statistic           = "Minimum"
   threshold           = "0"
+  treat_missing_data  = "breaching"
   alarm_description   = "This metric monitors webapp health"
   provider            = aws.us-east
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_service_alerts.arn] : []
@@ -37,6 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "service_health" {
   period              = "60"
   statistic           = "Minimum"
   threshold           = "0"
+  treat_missing_data  = "breaching"
   alarm_description   = "This metric monitors API service health"
   provider            = aws.us-east
   alarm_actions       = var.enable_alerts == true ? [aws_sns_topic.sns_service_alerts.arn] : []


### PR DESCRIPTION
## Context

When end to end testing I observed alarms went red in the dashboard but did not send an alert when no data was available i.e an ECS cluster was missing. Manually tested by changing the behaviour to 'breaching' for missing data and got the desired behaviour with the alert.

## Changes in this pull request

changed default behaviour for cw alarms for missing data to treat as breaching forcing the alarm to go red
